### PR TITLE
fix gadget single snapshot format

### DIFF
--- a/src/readers/gadget_unformatted.f
+++ b/src/readers/gadget_unformatted.f
@@ -23,10 +23,12 @@
       parti=0
       do ifile=0,files_per_snap-1 
         write(iter_string,'(i3.3)') iter
-        fil1='./simulation/snapdir_'//iter_string//'/snap_'//iter_string
+        fil1='./simulation/'
         if (files_per_snap.eq.1) then
-          fil2=fil1
+          fil2=fil1//'/snap_'//iter_string
         else
+          fil1=trim(adjustl(fil1))//'snapdir_'//iter_string//
+     &                            '/snap_'//iter_string
           write(ifile_string,'(i7.1)') ifile
           fil2=trim(adjustl(fil1))//'.'//trim(adjustl(ifile_string))
         end if


### PR DESCRIPTION
For single snapshots, the location should be snap_XXX.
The snapshot is not located in snapdir_XXX.